### PR TITLE
Git LFS Support for *.png and *.mb

### DIFF
--- a/HoloToolkit-Unity-App/.gitattributes
+++ b/HoloToolkit-Unity-App/.gitattributes
@@ -1,0 +1,2 @@
+*.png filter=lfs diff=lfs merge=lfs -text
+*.mb filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
`git lfs track "*.png" "*.mb"`
